### PR TITLE
Revert "SLING-11442 - Allow blocking after the features have been launched"

### DIFF
--- a/src/main/java/org/apache/sling/maven/feature/launcher/StartMojo.java
+++ b/src/main/java/org/apache/sling/maven/feature/launcher/StartMojo.java
@@ -96,9 +96,6 @@ public class StartMojo extends AbstractMojo {
     @Component
     private ProcessTracker processes;
     
-    @Parameter
-    private boolean block;
-
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -200,11 +197,6 @@ public class StartMojo extends AbstractMojo {
                 }
                 
                 processes.startTracking(launch.getId(), process);
-            }
-
-            if ( block ) {
-                getLog().info("Waiting until any key is pressed");
-                System.in.read();
             }
 
         } catch (ArtifactResolutionException | IOException e) {


### PR DESCRIPTION
This reverts commit 15236c7f4517d299e34335dba21bc99a09b65659, as this overlaps
with the work from SLING-10364 and it's not yet clear what a "proper" solution is.