### PR TITLE
SLING-11934 - Disable invoker ITs on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,4 +194,19 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <!-- remove once SLING-11934 is fixed -->
+        <profile>
+            <id>skip-invoker-windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <invoker.skip>true</invoker.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This will be re-enabled once we have the tests running as expected on Jenkins.